### PR TITLE
feat: allow loading of custom configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,43 @@
+<!--
+SPDX-FileCopyrightText: 2022 Jason Maassen (Netherlands eScience Center) <j.maassen@esciencecenter.nl>
+SPDX-FileCopyrightText: 2022 Jesús García Gonzalez (Netherlands eScience Center) <j.g.gonzalez@esciencecenter.nl>
+SPDX-FileCopyrightText: 2022 Netherlands eScience Center
+SPDX-FileCopyrightText: 2023 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
+SPDX-FileCopyrightText: 2023 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
+
+SPDX-License-Identifier: CC-BY-4.0
+-->
+
 # Documenting the RSD
 
 [Visit the documentation here.](https://research-software-directory.github.io/documentation)
 
 Any changes merge to the main branch will trigger automatically a build deploy to github pages.
 
-## Running locally: 
+## Configuration
+
+Vuepress is configured via [docs/.vuepress/config.js](docs/.vuepress/config.js).
+
+If you would like to host a customised version of this documentation, you can create a `docs/.vuepress/custom_config.js`. This configuration will overwrite the default configuration.
+
+**NOTE:** If you create a custom configuration by copy-pasting `docs/.vuepress/config.js`, remember to remove the `try` block:
+
+```javascript
+try {
+  conf = require('./custom_config')
+  console.log("Loading custom configuration.")
+} catch (ex) {
+  console.log("No custom configuration found. Using standard configuration.")
+}
+```
+
+## Running locally:
+
 ```bash
-yarn install 
+yarn install
 yarn dev
 ```
+
 ## Add a new document to the guide
 
-Edit the information inside the `/docs` folder. 
+Edit the information inside the `/docs` folder.

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -1,9 +1,11 @@
 // SPDX-FileCopyrightText: 2022 Jesús García Gonzalez (Netherlands eScience Center) <j.g.gonzalez@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2022 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
+// SPDX-FileCopyrightText: 2023 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 //
 // SPDX-License-Identifier: Apache-2.0
 
-module.exports = {
+let conf = {
   // site config
   lang: 'en-US',
   title: 'RSD Documentation',
@@ -60,6 +62,14 @@ module.exports = {
       },
     ],
   ],
-
-
 }
+
+
+try {
+  conf = require('./custom_config')
+  console.log("Loading custom configuration.")
+} catch (ex) {
+  console.log("No custom configuration found. Using standard configuration.")
+}
+
+module.exports = conf


### PR DESCRIPTION
This PR implements the option for a custom configuration file.

It will allow to customise anything related to the vuepress configuraiton of the documentation. This way, a fork of this documentation can be hosted without having to diverge from this repository.

How to test:

* `yarn install && yarn dev` -> http://localhost:3030/documentation/ is the standard documentation
* create a copy of `config.js` and name it `custom_config.js` and change something in this file, e.g. order in the sidebar.
* remove the following lines in `custom_config.js` so it doesn't try to load itself:
  ```javascript
  try {
    conf = require('./custom_config')
    console.log("Loading custom configuration.")
  } catch (ex) {
    console.log("No custom configuration found. Using standard configuration.")
  }
  ```
* `yarn dev` -> http://localhost:3030/documentation/ will now be configured according to `custom_config.js`

I am not sure whether the `try` approach is the best, but it works. I am open for suggestions though .
